### PR TITLE
Fix the Traceback error when trying to access a non-existent region

### DIFF
--- a/lib/mist/ec2/__init__.py
+++ b/lib/mist/ec2/__init__.py
@@ -1,0 +1,18 @@
+import re
+
+import boto.ec2
+from cog.logger import Logger
+from cog.command import Command
+
+class EC2Command(Command):
+
+    def connect(self):
+        self.region_name = self.req.option("region")
+        try:
+            self.region = boto.ec2.connect_to_region(self.region_name)
+        except Exception as e:
+            Logger.error("Error connecting to EC2: %s" % (e))
+            self.resp.send_error("Cannot connect to EC2")
+        if not self.region:
+            Logger.error("Error: Unknown region: %s" % (self.region_name))
+            self.resp.send_error("Sorry. The region '%s' is unknown." % (self.region_name))

--- a/lib/mist/ec2/keypairs.py
+++ b/lib/mist/ec2/keypairs.py
@@ -1,9 +1,7 @@
-import boto.ec2
-
 from cog.logger import Logger
-from cog.command import Command
+from mist.ec2 import EC2Command
 
-class ListKeypairsCommand(Command):
+class ListKeypairsCommand(EC2Command):
     def list_keypairs(self):
         keypairs = []
         names = self.req.args()
@@ -19,12 +17,7 @@ class ListKeypairsCommand(Command):
             self.resp.append_body({"keypairs": keypairs}, template="list_keypairs")
 
     def prepare(self):
-        self.region_name = self.req.option("region")
-        try:
-            self.region = boto.ec2.connect_to_region(self.region_name)
-        except Exception as e:
-            Logger.error("Error connecting to EC2: %s" % (e))
-            self.resp.send_error("Cannot connect to EC2")
+        self.connect()
         self.handlers["default"] = self.list_keypairs
 
     def usage_error(self):


### PR DESCRIPTION
This change covers refactor the EC2 connection code for each of the EC2 classes that connect to EC2 based on the region. If the region is not set, an error is sent to the user that they have entered an invalid region.

Fixes #244